### PR TITLE
Refactor

### DIFF
--- a/awslimits/data_setup.py
+++ b/awslimits/data_setup.py
@@ -1,11 +1,12 @@
 from support import load_tickets, load_default_limits
-
+import settings
 
 def update_data():
     print 'loading default limits...'
     load_default_limits()
-    print 'loading tickets...'
-    load_tickets()
+    if settings.PREMIUM_ACCOUNT:
+        print 'loading tickets...'
+        load_tickets()
     print 'done'
 
 if __name__ == "__main__":

--- a/awslimits/manage.py
+++ b/awslimits/manage.py
@@ -33,7 +33,7 @@ def send_alerts():
 					'to': recipients
 				}
 			],
-			'subject': "AWS Limit Alerts for {}".format(settings.ROLE_ARN.split('/')[-1]),
+			'subject': "AWS Limit Alerts for ID {}".format(settings.ACCOUNT_ID),
 		}
 		sg.client.mail.send.post(request_body=data)
 		save_sent_alerts(limits_for_alert)

--- a/awslimits/settings.py
+++ b/awslimits/settings.py
@@ -19,8 +19,7 @@ LIMIT_ALERT_PERCENTAGE = int(os.environ.get("LIMIT_ALERT_PERCENTAGE", 90))
 
 SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY")
 EMAIL_RECIPIENTS = os.environ.get('EMAIL_RECIPIENTS')
-FROM_EMAIL_ADDRESS = os.environ.get('FROM_EMAIL_ADDRESS')
+FROM_EMAIL_ADDRESS = os.environ.get('FROM_EMAIL_ADDRESS', 'awslimits@alerts.com')
 FROM_EMAIL_NAME = os.environ.get('FROM_EMAIL_NAME')
 
 assert SENDGRID_API_KEY, "Need to pass a SendGrid API key. Create one here: https://app.sendgrid.com/settings/api_keys"
-

--- a/awslimits/settings.py
+++ b/awslimits/settings.py
@@ -11,7 +11,7 @@ ROLE_ARN = os.environ.get("ROLE_ARN")
 ACCOUNT_ID = re.findall('\d+', ROLE_ARN)[0]
 ACCOUNT_ROLE = ROLE_ARN.split('/')[-1]
 REGION_NAME = os.environ.get("REGION_NAME", "us-east-1")
-PREMIUM_ACCOUNT = int(os.environ.get("PREMIUM_ACCOUNT", 0))
+PREMIUM_ACCOUNT = int(os.environ.get("PREMIUM_ACCOUNT", 1))
 
 assert ROLE_ARN, "Need to pass a role ARN"
 

--- a/awslimits/settings.py
+++ b/awslimits/settings.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 APP_MODULE="awslimits.server"
 APP_OBJECT="app"
@@ -7,6 +8,8 @@ SECRET_KEY = "xC^UHBQO&@^Gj^EICCY0"
 WTF_CSRF_SECRET_KET = SECRET_KEY
 
 ROLE_ARN = os.environ.get("ROLE_ARN")
+ACCOUNT_ID = re.findall('\d+', ROLE_ARN)[0]
+ACCOUNT_ROLE = ROLE_ARN.split('/')[-1]
 REGION_NAME = os.environ.get("REGION_NAME", "us-east-1")
 
 assert ROLE_ARN, "Need to pass a role ARN"

--- a/awslimits/settings.py
+++ b/awslimits/settings.py
@@ -11,6 +11,7 @@ ROLE_ARN = os.environ.get("ROLE_ARN")
 ACCOUNT_ID = re.findall('\d+', ROLE_ARN)[0]
 ACCOUNT_ROLE = ROLE_ARN.split('/')[-1]
 REGION_NAME = os.environ.get("REGION_NAME", "us-east-1")
+PREMIUM_ACCOUNT = int(os.environ.get("PREMIUM_ACCOUNT", 0))
 
 assert ROLE_ARN, "Need to pass a role ARN"
 

--- a/awslimits/support.py
+++ b/awslimits/support.py
@@ -52,6 +52,9 @@ def get_boto_client(client):
     )
 
 
+def get_aws_limit_checker():
+    return AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
+
 def get_tickets_table():
     return create_or_get_table(
         table_name=TICKETS_TABLE_NAME,
@@ -105,7 +108,7 @@ def load_tickets():
 
 def get_limit_types():
     limit_types = []
-    checker = AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
+    checker = get_aws_limit_checker()
     for service, service_limits in checker.get_limits(use_ta=settings.PREMIUM_ACCOUNT).items():
         for service_name, service_limit in service_limits.items():
             limit_types.append(NAME_SEPARATOR.join([service, service_name]))
@@ -155,7 +158,7 @@ def update_ticket(form):
 
 def update_limit_value(limit_type):
     service, limit_name = limit_type.split(NAME_SEPARATOR)
-    checker = AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
+    checker = get_aws_limit_checker()
     limits = checker.get_limits(use_ta=settings.PREMIUM_ACCOUNT)
     default_limit = limits[service][limit_name].default_limit
 
@@ -220,7 +223,7 @@ def load_default_limits():
 
     existing_limit_names = [limit['limit_name'] for limit in table.scan()['Items']]
 
-    checker = AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
+    checker = get_aws_limit_checker()
     checker.find_usage()
 
     limits = checker.get_limits(use_ta=settings.PREMIUM_ACCOUNT)

--- a/awslimits/support.py
+++ b/awslimits/support.py
@@ -105,7 +105,7 @@ def load_tickets():
 
 def get_limit_types():
     limit_types = []
-    checker = AwsLimitChecker(region=settings.REGION_NAME, account_role=settings.ROLE_ARN)
+    checker = AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
     for service, service_limits in checker.get_limits(use_ta=False).items():
         for service_name, service_limit in service_limits.items():
             limit_types.append(NAME_SEPARATOR.join([service, service_name]))
@@ -155,7 +155,7 @@ def update_ticket(form):
 
 def update_limit_value(limit_type):
     service, limit_name = limit_type.split(NAME_SEPARATOR)
-    checker = AwsLimitChecker(region=settings.REGION_NAME, account_role=settings.ROLE_ARN)
+    checker = AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
     limits = checker.get_limits()
     default_limit = limits[service][limit_name].default_limit
 
@@ -220,7 +220,7 @@ def load_default_limits():
 
     existing_limit_names = [limit['limit_name'] for limit in table.scan()['Items']]
 
-    checker = AwsLimitChecker(region=settings.REGION_NAME, account_role=settings.ROLE_ARN)
+    checker = AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
     checker.find_usage()
 
     limits = checker.get_limits()

--- a/awslimits/support.py
+++ b/awslimits/support.py
@@ -106,7 +106,7 @@ def load_tickets():
 def get_limit_types():
     limit_types = []
     checker = AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
-    for service, service_limits in checker.get_limits(use_ta=False).items():
+    for service, service_limits in checker.get_limits(use_ta=settings.PREMIUM_ACCOUNT).items():
         for service_name, service_limit in service_limits.items():
             limit_types.append(NAME_SEPARATOR.join([service, service_name]))
     return sorted(limit_types)
@@ -156,7 +156,7 @@ def update_ticket(form):
 def update_limit_value(limit_type):
     service, limit_name = limit_type.split(NAME_SEPARATOR)
     checker = AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
-    limits = checker.get_limits()
+    limits = checker.get_limits(use_ta=settings.PREMIUM_ACCOUNT)
     default_limit = limits[service][limit_name].default_limit
 
     dynamodb = get_boto_resource('dynamodb')
@@ -223,7 +223,7 @@ def load_default_limits():
     checker = AwsLimitChecker(region=settings.REGION_NAME, account_id=settings.ACCOUNT_ID, account_role=settings.ACCOUNT_ROLE)
     checker.find_usage()
 
-    limits = checker.get_limits()
+    limits = checker.get_limits(use_ta=settings.PREMIUM_ACCOUNT)
 
     with table.batch_writer() as batch:
         for service, limit_set in limits.items():


### PR DESCRIPTION
@hltbra This PR covers the changes we previously discussed
* Moving all references to table calls into helpers that `get_or_create_table`
* Initializing the AwsLimitChecker with the `account_id` (ex: 123456789) in addition to the `account_role` (ex: awslimits), instead of just the full `role_arn`
* Considering whether or not an account is `premium`
* Updating mail formatting to more easily differentiate between accounts