### PR TITLE
Fix load tickets

### DIFF
--- a/awslimits/support.py
+++ b/awslimits/support.py
@@ -122,7 +122,7 @@ def get_ticket(ticket_id):
 def get_pending_tickets():
     table = get_tickets_table()
     cases = table.scan(
-        FilterExpression=Attr('limit_type').eq('unknown')
+        FilterExpression=Attr('limit_type').eq('unknown') & Attr('body').ne('N/A')
     )['Items']
     cases = sorted(cases, key=lambda case: case['display_id'], reverse=True)
     return cases

--- a/awslimits/support.py
+++ b/awslimits/support.py
@@ -63,19 +63,11 @@ def get_tickets_table():
                 'AttributeName': 'display_id',
                 'AttributeType': 'N',
             },
-            {
-                'AttributeName': 'created',
-                'AttributeType': 'N',
-            },
         ],
         key_schema=[
             {
                 'AttributeName': 'display_id',
                 'KeyType': 'HASH'
-            },
-            {
-                'AttributeName': 'created',
-                'KeyType': 'RANGE'
             },
         ],
     )
@@ -142,7 +134,6 @@ def update_ticket(form):
     table.update_item(
         Key={
             "display_id": form.display_id.data,
-            "created": form.created.data,
         },
         AttributeUpdates={
             'limit_type': {


### PR DESCRIPTION
@spulec This removes the created key from the `awslimits_tickets` table and updates the ticket attributes on `load_tickets`, as we discussed yesterday. I tested it on the staging account using a script to reload the data to the new table and it works as expected. I will update the tables on the other accounts once we are ready to merge and create a new version. If I do it now, it will create an error when the `refresh_data` cron job runs.

cc @hltbra 