### PR TITLE
Bugfix/snooze env var

### DIFF
--- a/awslimits/settings.py
+++ b/awslimits/settings.py
@@ -26,4 +26,5 @@ assert SENDGRID_API_KEY, "Need to pass a SendGrid API key. Create one here: http
 
 # list of limit names to snooze. Need split because of ::
 # ex: SNOOZE='S3 :: Buckets,VPC :: Subnets per VPC'
-SNOOZE = os.environ.get("SNOOZE").split(',')
+SNOOZE = os.environ.get("SNOOZE", '').replace('\'', '').replace('"', '')
+

--- a/awslimits/support.py
+++ b/awslimits/support.py
@@ -308,7 +308,7 @@ def get_recently_sent_alerts(limits):
 def get_limits_for_alert():
     limits = get_limits()
     recently_sent_alerts = get_recently_sent_alerts(limits)
-    return [x for x in limits if x['percent_used'] > LIMIT_ALERT_PERCENTAGE and x['limit_name'] not in recently_sent_alerts and not x['snooze']]
+    return [x for x in limits if x['percent_used'] >= LIMIT_ALERT_PERCENTAGE and x['limit_name'] not in recently_sent_alerts and not x['snooze']]
 
 
 def save_sent_alerts(alerts):

--- a/awslimits/support.py
+++ b/awslimits/support.py
@@ -339,13 +339,3 @@ def alert_email_body(limits):
         )
     body += '</ul>'
     return body
-
-
-def snooze(limits):
-    '''
-    Add key 'snooze' to certain limits
-    '''
-    for limit in limits:
-        if limit['limit_name'] in settings.SNOOZE:
-            limit['snooze'] = True
-    return limits

--- a/awslimits/templates/limits.html
+++ b/awslimits/templates/limits.html
@@ -22,7 +22,7 @@
                 <td>-</td>
             {% endif %}
             {% if limit['snooze'] %}
-                <td><i class="fa fa-bell-slash"></i></td>
+                <td title="Alerts for this limit have been disabled"><i class="fa fa-bell-slash"></i></td>
             {% endif %}
         </tr>
     </tbody>


### PR DESCRIPTION
I found two problems with the SNOOZE var that I had not seen locally. I also added a few small cleanups/style additions

The first was I didn't catch that there would be an error if a value wasn't passed, which has been fixed with a default value. The second is that because it's a comma delimited string with spaces, the quotation marks were getting grabbed based on the way we load vars in production